### PR TITLE
fix: add affiliations to repos query

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,7 +1,7 @@
 const repositories = `
   query repos($cursor: String) {
     viewer {
-      repositories(first:100, after: $cursor) {
+      repositories(first:100, after: $cursor, affiliations: [OWNER, COLLABORATOR, ORGANIZATION_MEMBER], ownerAffiliations: [OWNER, COLLABORATOR, ORGANIZATION_MEMBER]) {
         nodes{
           nameWithOwner
         }


### PR DESCRIPTION
See https://github.community/t/grapql-viewer-repositories-gets-only-repositories-where-the-user-is-collaborator/13579